### PR TITLE
Add outputs for using store images

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,29 @@ should stick to running `aarch64-linux` VM on your machine. To do so, add
 `--system aarch64-darwin` to your `nix run` and it will pick up the right
 package.
 
+### Broken sudo
+
+```
+[test@nixos:~]$ sudo poweroff
+sudo: error in /etc/sudo.conf, line 0 while loading plugin "sudoers_policy"
+sudo: /nix/store/kkn64rx0ns1kv8yadwclnwrny29n6inj-sudo-1.9.11p3/libexec/sudo/sudoers.so must be owned by uid 0
+sudo: fatal error, unable to load plugins
+```
+
+This probably means that you're using single-user (daemon-less) Nix
+installation and all `/nix/store` paths are owned by you instead of root. By
+default, VM shares `/nix/store` with the host, so things like `sudoers.so` ends
+up with wrong permissions. This can be fixed by using a qcow image with all
+necessary store path for the VM. There's a special output that has already been
+build and cached for this. To use it, run
+
+```
+nix run github:YorikSar/nixos-vm-on-macos#withStoreImage
+```
+
+Note that it will download the image from the cache for you that weight about
+1Gb.
+
 ### There's a different issue
 
 Feel free to ask about it in 

--- a/flake.nix
+++ b/flake.nix
@@ -30,12 +30,26 @@
           # Make it output to the terminal instead of separate window
           virtualisation.graphics = false;
         };
+      withStoreImage = {
+        virtualisation.useNixStoreImage = true;
+        virtualisation.writableStore = true;
+      };
     };
     nixosConfigurations = {
       vm-x86_64 = nixpkgs.lib.nixosSystem {
         system = "x86_64-linux";
         modules = [
           self.nixosModules.vm
+          {
+            virtualisation.host.pkgs = nixpkgs.legacyPackages.x86_64-darwin;
+          }
+        ];
+      };
+      vm-x86_64-storeImage = nixpkgs.lib.nixosSystem {
+        system = "x86_64-linux";
+        modules = [
+          self.nixosModules.vm
+          self.nixosModules.withStoreImage
           {
             virtualisation.host.pkgs = nixpkgs.legacyPackages.x86_64-darwin;
           }
@@ -50,9 +64,21 @@
           }
         ];
       };
+      vm-aarch64-storeImage = nixpkgs.lib.nixosSystem {
+        system = "aarch64-linux";
+        modules = [
+          self.nixosModules.vm
+          self.nixosModules.withStoreImage
+          {
+            virtualisation.host.pkgs = nixpkgs.legacyPackages.aarch64-darwin;
+          }
+        ];
+      };
     };
     packages.x86_64-darwin.default = self.nixosConfigurations.vm-x86_64.config.system.build.vm;
+    packages.x86_64-darwin.withStoreImage = self.nixosConfigurations.vm-x86_64-storeImage.config.system.build.vm;
     packages.aarch64-darwin.default = self.nixosConfigurations.vm-aarch64.config.system.build.vm;
+    packages.aarch64-darwin.withStoreImage = self.nixosConfigurations.vm-aarch64-storeImage.config.system.build.vm;
   };
 
   nixConfig = {


### PR DESCRIPTION
This should allow people using single-user Nix installation to use these VMs.

Test with

```
nix run github:YorikSar/nixos-vm-on-macos/store-image#withStoreImage
```